### PR TITLE
feat(fonts): lazy glyph-atlas loading to reduce idle memory footprint (#77)

### DIFF
--- a/docs/font-atlas-loading.md
+++ b/docs/font-atlas-loading.md
@@ -1,0 +1,253 @@
+# Font Atlas Loading
+
+> How Selkie bakes glyphs into font atlases at startup, and grows them
+> on demand as documents and user input need codepoints beyond the
+> eager default set.
+
+## Overview
+
+Each of Selkie's 5 font variants (regular/bold/italic/bold-italic/mono) is
+backed by a raylib `Font`, which bakes a fixed set of Unicode codepoints
+into a GPU texture atlas at load time (`rl.loadFontEx`). Historically this
+set was the full ~2,135-codepoint table in
+[`unicode_codepoints.zig`](../src/unicode_codepoints.zig), baked
+unconditionally on every startup regardless of what the opened document
+actually needed — a fixed cost that dominated idle memory (see
+[Memory Profiling — Issue #77](memory-profiling.md) for the measurements
+that motivated this change).
+
+This document describes the tiered eager/lazy loading scheme that replaced
+that: a small default set is baked at startup, and the remainder is loaded
+only when a document or user input actually requires it.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Startup
+        LF["App.loadFonts()"] --> LFV["App.loadFontVariants(default_codepoints)"]
+        LFV --> Fonts["self.fonts: 5 baked Font atlases"]
+        LF --> LS["self.loaded_codepoints = LoadedSet.init()\n(seeded with default_codepoints)"]
+    end
+
+    subgraph "On demand"
+        Src["Tab source / typed char / pasted text"] --> Scan["unicode_codepoints.addUtf8Codepoints"]
+        Scan --> EG["App.ensureGlyphs(codepoints)"]
+        EG -->|"all already loaded"| NoOp["no-op"]
+        EG -->|"new codepoints found"| Rebuild["App.loadFontVariants(expanded set)"]
+        Rebuild --> Swap["unloadFonts(old) + fonts = new"]
+        Swap --> Commit["loaded_codepoints := expanded"]
+    end
+
+    LS -.->|read/grown by| EG
+```
+
+Two codepoint tables in `src/unicode_codepoints.zig` partition the same
+Unicode range coverage that used to be one flat table:
+
+| Table | Codepoints | When loaded |
+|-------|-----------:|--------------|
+| `default_codepoints` | 303 | Eagerly, every `App.loadFonts()` call (startup, theme reload) |
+| `remainder_codepoints` | ~1,832 | Lazily, only via `App.ensureGlyphs` when actually needed |
+
+`default_ranges` covers Basic Latin, Latin-1 Supplement, and General
+Punctuation — enough for plain English/Western-European prose with curly
+quotes and em dashes on the first frame with no rebuild. `remainder_ranges`
+covers everything else the old single table had: Latin Extended-A/B, Greek,
+super/subscripts, currency, letterlike symbols, arrows, math operators,
+misc technical, geometric shapes, misc symbols, dingbats, ligatures, and
+the replacement character.
+
+## Components
+
+### `unicode_codepoints.LoadedSet`
+
+Growth-only record of which codepoints are currently baked into
+`App.fonts`. Backed by `std.AutoHashMap(i32, void)`.
+
+| Method | Behavior |
+|--------|----------|
+| `init(allocator)` | Seeds the set with all of `default_codepoints` |
+| `contains(cp)` | O(1) membership check |
+| `add(cp)` | Inserts `cp`; returns whether it was new |
+| `deinit()` | Frees the backing map |
+
+It only ever grows, mirroring the fact that an atlas rebuild is always
+"old set plus new codepoints," never a shrink — there's no use case for
+evicting glyphs mid-session.
+
+### `App.loadFontVariants(codepoints)`
+
+Bakes all 5 font variants at the fixed 32px size from `assets/fonts/`
+using the given codepoint slice, returning a `Fonts` value without
+touching `self.fonts`. Callers decide when to swap it in, so a failed
+rebuild never leaves `self.fonts` null. Any variant baked before a later
+failure in the same call is unloaded via `errdefer`.
+
+### `App.loadFonts()`
+
+The startup path: bakes `default_codepoints` only, and (re)seeds
+`self.loaded_codepoints` to track that set. Called from `main.zig` after
+window/GL init and on theme reload.
+
+### `App.ensureGlyphs(codepoints) !bool`
+
+The core lazy-loading entry point. Given a slice of codepoints:
+
+1. Cheap pre-check against `LoadedSet.contains` — if every codepoint is
+   already loaded, returns `false` with no allocation.
+2. Otherwise stages growth in a **clone** of `loaded_codepoints`'s map
+   (`self.fonts == null` — no atlas exists yet — skips staging and commits
+   directly, since there's nothing to fall out of sync with).
+3. Rebuilds all 5 atlases via `loadFontVariants` with the expanded set.
+4. Only after the rebuild succeeds: unloads the old atlas, swaps in the
+   new one, and commits the staged set into `loaded_codepoints`.
+
+Returns `true` if the atlas grew (callers that measure text, e.g. before
+a relayout, must treat this as "stale metrics, re-measure"), `false` if
+it was a no-op.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant EG as App.ensureGlyphs
+    participant Set as loaded_codepoints
+    participant LFV as loadFontVariants
+
+    Caller->>EG: ensureGlyphs(codepoints)
+    EG->>Set: contains(cp) for each cp
+    alt all already loaded
+        EG-->>Caller: false (no-op)
+    else new codepoints present
+        EG->>Set: clone map into `staged`
+        EG->>LFV: bake expanded atlas
+        alt rebuild fails
+            LFV-->>EG: error
+            EG-->>Caller: propagate error (fonts + loaded_codepoints untouched)
+        else rebuild succeeds
+            LFV-->>EG: new Fonts
+            EG->>EG: unloadFonts(old) + fonts = new
+            EG->>Set: commit staged (map = staged)
+            EG-->>Caller: true (atlas grew, re-measure)
+        end
+    end
+```
+
+### `App.ensureGlyphsForTab(tab, sources)`
+
+Document-load integration point, called from `newTabWithFile` (with the
+markdown source and file path — the path is scanned because it becomes
+the tab title, drawn with the same atlas) and `loadMarkdownDirect` (stdin
+path).
+
+Collects the codepoint union of:
+- A raw UTF-8 scan of `sources` (covers prose, code, tables, headings,
+  and literal Mermaid node/edge/title text, since Mermaid labels are
+  plain text inside the fenced source).
+- A walk of the tab's `layout_tree` text runs (covers glyphs with no
+  literal source representation, e.g. math symbols synthesized from
+  LaTeX during layout).
+
+Calls `ensureGlyphs` with the union, and relayouts the tab once if it
+returned `true` — mirroring the existing double-relayout pattern already
+used for details-state restoration.
+
+### Runtime hooks: `ensureGlyphForChar` / `ensureGlyphsForBytes`
+
+Called from the editor, search, and command-palette input handlers:
+
+- `ensureGlyphForChar(codepoint)` — one codepoint at a time, from
+  `rl.getCharPressed()` (already decoded, so no UTF-8 scan needed).
+- `ensureGlyphsForBytes(inserted)` — a UTF-8 byte slice, from editor
+  paste (clipboard content arrives as raw bytes, not one char at a time).
+
+Neither triggers a relayout directly: the editor's existing
+`edit_version`-driven live-preview reparse (checked every frame in
+`update()`) re-measures against the atlas on the same frame, since these
+hooks run earlier in the frame than that check.
+
+## Data Flow — opening a document
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant Tab
+    participant Font as Font Atlas
+
+    User->>App: open file.md
+    App->>Tab: loadMarkdown + layout (against current atlas)
+    App->>App: ensureGlyphsForTab(tab, [content, path])
+    App->>App: scan content+path (UTF-8) union layout_tree text runs
+    App->>App: ensureGlyphs(union)
+    alt union has new codepoints
+        App->>Font: rebuild 5 atlases with expanded set
+        App->>Tab: relayout (metrics now consistent with atlas)
+    else union already covered
+        App-->>User: render immediately, no rebuild
+    end
+```
+
+## Key Types
+
+| Type | Location | Role |
+|------|----------|------|
+| `LoadedSet` | `src/unicode_codepoints.zig` | Growth-only record of baked codepoints |
+| `default_codepoints` / `remainder_codepoints` | `src/unicode_codepoints.zig` | Comptime-built codepoint tables (303 / ~1,832) |
+| `App.loaded_codepoints: ?LoadedSet` | `src/app.zig` | Per-app instance of `LoadedSet`; `null` until `loadFonts` runs |
+| `App.fonts: ?Fonts` | `src/app.zig` | The 5 baked `raylib.Font` atlases currently in use |
+
+## Invariants
+
+- **`loaded_codepoints` never shrinks.** Codepoints are only ever added;
+  there is no eviction path.
+- **A failed rebuild never tears down a working atlas.** `loadFontVariants`
+  builds the replacement fully before `ensureGlyphs` calls `unloadFonts`
+  on the old one; if baking fails, the error propagates before either the
+  swap or the `loaded_codepoints` commit happens.
+- **Growth is staged, not applied speculatively.** `ensureGlyphs` clones
+  `loaded_codepoints`'s map into a scratch copy and only writes it back
+  after the atlas rebuild that describes it has actually succeeded —
+  otherwise a failed rebuild would permanently mark codepoints "loaded"
+  with no glyph ever baked for them, blocking any future retry.
+- **One rebuild per call, never proliferating atlases.** All 5 variants
+  are rebuilt together from the full expanded set, not incrementally
+  patched — raylib has no API to add glyphs to an existing atlas texture.
+
+## Error Handling
+
+`ensureGlyphs` and `loadFontVariants` return Zig error unions and
+propagate allocation/font-loading failures to callers. The three
+`App`-level integration points (`ensureGlyphsForTab`,
+`ensureGlyphForChar`, `ensureGlyphsForBytes`) are frame-loop callers that
+cannot themselves fail the frame, so they catch and `std.log.err` rather
+than propagating — consistent with the rest of `App`'s per-frame update
+path (see `relayoutActiveTab` for the same pattern).
+
+## Configuration
+
+The default/remainder split is fixed at comptime in
+`src/unicode_codepoints.zig` (`default_ranges` / `remainder_ranges`); there
+is no runtime or theme-level configuration for it. Changing which
+codepoints are eager vs. lazy means editing those range tables and
+re-running the `unicode_codepoints.zig` test block, which pins exact
+counts (`default_codepoints.len == 303`) to catch accidental range drift.
+
+## Decision Log
+
+The eager/lazy split, the 303-codepoint default set, and the measured
+memory impact are recorded in
+[Memory Profiling — Issue #77](memory-profiling.md), including the
+atlas-isolation experiment that justified building this mechanism and the
+BEFORE/AFTER RSS comparison after it shipped.
+
+## References
+
+- [Memory Profiling — Issue #77](memory-profiling.md) — profiling
+  procedure, BEFORE/AFTER results, go/no-go rationale
+- [`src/unicode_codepoints.zig`](../src/unicode_codepoints.zig) —
+  codepoint tables, `LoadedSet`, UTF-8 scanning helpers
+- [`src/app.zig`](../src/app.zig) — `loadFonts`, `ensureGlyphs`,
+  `ensureGlyphsForTab`, runtime hooks
+- `CLAUDE.md` — project-wide memory management and error-handling
+  conventions this module follows

--- a/docs/memory-profiling.md
+++ b/docs/memory-profiling.md
@@ -1,0 +1,168 @@
+# Memory Profiling Procedure (Issue #77)
+
+This document is the reproducible `/usr/bin/time -v` procedure for measuring
+Selkie's idle peak RSS and startup time, and the baseline (BEFORE) results
+that gate the lazy font-atlas work tracked in issue #77.
+
+Raw `/usr/bin/time -v` output is **not** committed — regenerate it locally
+with the steps below. Only this procedure and its summarized results are
+tracked.
+
+## Why `--export-png`
+
+Selkie has no daemon/idle mode to attach a profiler to at rest, so the
+hidden-window `--export-png` path is used as the closest proxy for "idle
+after opening a document": it drives the full startup sequence (window +
+GL context init, `App.loadFonts()`, file load, parse, layout, one render
+pass, PNG write, clean shutdown) without showing a GUI window, and it exits
+deterministically so `/usr/bin/time -v` can capture peak RSS for the whole
+process lifetime. This is the same code path documented in
+`CLAUDE.md` under "PNG Export (screenshots)".
+
+## Prerequisites
+
+- A release build, since that's what ships (`packaging/arch/PKGBUILD` and
+  `.github/workflows/build.yml` both build `-Doptimize=ReleaseSafe`):
+
+  ```bash
+  zig build -Doptimize=ReleaseSafe
+  ```
+
+  Note: this build currently prints `ld.lld: warning: ... is neither ET_REL
+  nor LLVM bitcode` lines for raylib's dynamically-linked system libs
+  (GLX/X11/EGL/wayland/etc.) and zig's build runner echoes them under an
+  `error: warning(link): ...` banner. This is pre-existing linker noise, not
+  a build failure — `zig build` still exits 0 and `zig-out/bin/selkie` is
+  produced. Verify with `echo $?` if the banner is alarming.
+
+- `/usr/bin/time -v` (GNU time; not the shell builtin `time`). Confirm it
+  exists before relying on `-v`:
+
+  ```bash
+  /usr/bin/time -v true
+  ```
+
+- A live X11/Wayland display (`$DISPLAY` or `$WAYLAND_DISPLAY` set). Even
+  though the export window is hidden, raylib still creates a real GL
+  context, so this does not run under a display-less CI runner without a
+  virtual display (Xvfb) — none was available in this environment, and none
+  was needed since a real display was present.
+
+## Test fixtures
+
+**One-line file** — minimal document, generated inline (not committed as a
+fixture):
+
+```bash
+printf '# Hello\n' > /tmp/one-line.md
+```
+
+**Full sample document** — the existing tracked fixture:
+
+```
+docs/github-markdown-samples.md   # 936 lines, full GFM surface incl. Mermaid
+```
+
+## Measurement command
+
+Run from the repo root (or worktree root), quiet mode to suppress log noise,
+hidden-window PNG export to a throwaway path:
+
+```bash
+BIN=./zig-out/bin/selkie
+
+/usr/bin/time -v "$BIN" --export-png /tmp/out.png /tmp/one-line.md -q 2> /tmp/oneline_run.txt
+grep -E "Maximum resident|Elapsed" /tmp/oneline_run.txt
+
+/usr/bin/time -v "$BIN" --export-png /tmp/out.png docs/github-markdown-samples.md -q 2> /tmp/sample_run.txt
+grep -E "Maximum resident|Elapsed" /tmp/sample_run.txt
+```
+
+Take the **first** invocation after a fresh build as "cold" (binary/font/theme
+files not yet in the OS page cache from a prior run of this exact binary) and
+at least two subsequent invocations as "warm" (page cache populated). This
+environment has no root access to `echo 3 > /proc/sys/vm/drop_caches`
+between runs, so "cold" here means "first run after (re)build," not
+"cold OS page cache" in the strictest sense — note this caveat when
+comparing across machines/CI.
+
+`Maximum resident set size` from `/usr/bin/time -v` is `ru_maxrss`, reported
+in KiB (1024-byte units) on Linux.
+
+## BEFORE results (this commit, `-Doptimize=ReleaseSafe`)
+
+Environment: Linux 7.0.5-200.nobara.fc43.x86_64, live X11 display, Zig
+0.14.1.
+
+### One-line file (`printf '# Hello\n'`)
+
+| Run | Peak RSS (KiB) | Peak RSS (MiB) | Elapsed |
+|-----|---------------:|---------------:|--------:|
+| 1 (cold, first post-build) | 199,148 | 194.5 | 0.46s |
+| 2 (warm) | 199,428 | 194.8 | 0.44s |
+| 3 (warm) | 198,980 | 194.3 | 0.42s |
+
+### Full sample doc (`docs/github-markdown-samples.md`, 936 lines)
+
+| Run | Peak RSS (KiB) | Peak RSS (MiB) | Elapsed |
+|-----|---------------:|---------------:|--------:|
+| 1 (cold) | 201,240 | 196.5 | 0.41s |
+| 2 (warm) | 201,524 | 196.8 | 0.40s |
+| 3 (warm) | 201,872 | 197.1 | 0.37s |
+
+**Observation:** peak RSS is ~199MB for a one-line file and ~201MB for the
+936-line sample doc — a ~2MB delta for a ~100x increase in document size.
+This confirms the issue's premise: idle peak RSS is dominated by a
+document-size-independent fixed cost (window/GL context init + eager font
+atlas bake), not by the document being viewed. This is the BEFORE baseline
+against which the lazy-atlas work is compared.
+
+## Atlas isolation experiment (confirms material share)
+
+To directly attribute part of that fixed cost to the eager 32px/5-variant
+glyph atlas (`src/unicode_codepoints.zig`, 2,135 codepoints x 5 font
+variants = 10,675 baked glyph slots), `ranges` in
+`src/unicode_codepoints.zig` was temporarily reduced to ASCII-only
+(`0x0020`-`0x007E`, 95 codepoints) with all other ranges commented out,
+rebuilt, measured against the one-line file, then reverted and rebuilt back
+to the original (verified via `git status`/`git diff` showing no residual
+changes, and a confirmation run matching the original baseline: 199,672
+KiB).
+
+| Config | Peak RSS (KiB, avg of 3) |
+|--------|-------------------------:|
+| Full atlas (2,135 cp x 5 variants) | 199,185 |
+| ASCII-only atlas (95 cp x 5 variants) | 180,940 |
+
+**Delta: ~18.2MB (~9-10% of the ~199MB baseline)** attributable purely to
+expanding the eager codepoint set from 95 to 2,135 codepoints across 5 font
+variants.
+
+## Go/no-go verdict: **GO**
+
+The atlas is a **material but not dominant** share of the ~200MB baseline:
+- ~18MB of the ~199MB is directly attributable to the eager 2,135-codepoint
+  x 5-variant atlas bake — large enough that lazy-loading it is worth
+  building, and directly addressable by the planned `ensureGlyphs` work.
+- The remaining ~181MB (ASCII-only floor) is fixed cost from raylib window
+  creation, the OpenGL/GLX context, and base runtime/allocator overhead —
+  **not addressable by font work**. This means the lazy-atlas change alone
+  should shave a real ~15-20MB off idle RSS for small documents, but is
+  very unlikely, by itself, to hit the issue's `<100MB` (or `<80MB`)
+  stretch target — that floor sits at ~181MB regardless of font strategy.
+- Per the adjudicated contrarian caveat ("measure atlas share first before
+  building the machinery"), this is sufficient evidence to proceed with the
+  lazy-loading implementation (tasks 2-5): the atlas is confirmed as a real,
+  measurable, material contributor, not a rounding error. Downstream tasks
+  should still record the AFTER numbers against this same procedure so the
+  actual achieved reduction (not just the isolated delta) is documented,
+  and the `<100MB` target should be understood as aspirational against a
+  ~181MB non-font floor rather than a hard commitment this task alone can
+  deliver.
+
+## Reproducing AFTER measurement (for later tasks)
+
+Once lazy loading lands, rerun the exact same commands in "Measurement
+command" above against the same two fixtures on the same machine, and
+append a comparison table (BEFORE vs AFTER, one-line file and full sample
+doc, cold + warm) to this document or to the closing issue comment.

--- a/docs/memory-profiling.md
+++ b/docs/memory-profiling.md
@@ -8,6 +8,10 @@ Raw `/usr/bin/time -v` output is **not** committed — regenerate it locally
 with the steps below. Only this procedure and its summarized results are
 tracked.
 
+For how the lazy-loading mechanism itself works (the eager/lazy codepoint
+split, `LoadedSet`, `App.ensureGlyphs`), see
+[Font Atlas Loading](font-atlas-loading.md).
+
 ## Why `--export-png`
 
 Selkie has no daemon/idle mode to attach a profiler to at rest, so the

--- a/docs/memory-profiling.md
+++ b/docs/memory-profiling.md
@@ -160,9 +160,113 @@ The atlas is a **material but not dominant** share of the ~200MB baseline:
   ~181MB non-font floor rather than a hard commitment this task alone can
   deliver.
 
-## Reproducing AFTER measurement (for later tasks)
+## AFTER results (lazy font-atlas loading, tasks 2-4 applied)
 
-Once lazy loading lands, rerun the exact same commands in "Measurement
-command" above against the same two fixtures on the same machine, and
-append a comparison table (BEFORE vs AFTER, one-line file and full sample
-doc, cold + warm) to this document or to the closing issue comment.
+Same machine, same procedure, same `-Doptimize=ReleaseSafe` build, run
+immediately after `zig build -Doptimize=ReleaseSafe` at commit `2c9ac05`
+(final commit of tasks 1-4).
+
+### One-line file (`printf '# Hello\n'`)
+
+| Run | Peak RSS (KiB) | Peak RSS (MiB) | Elapsed |
+|-----|---------------:|---------------:|--------:|
+| 1 (cold, first post-build) | 189,092 | 184.7 | 1.49s |
+| 2 (warm) | 190,004 | 185.5 | 0.34s |
+| 3 (warm) | 189,736 | 185.3 | 0.36s |
+
+The one-line doc's eager atlas is the default set only (303 codepoints x 5
+variants) — `ensureGlyphs` never triggers a rebuild for it, since `# Hello`
+contains nothing outside Basic Latin.
+
+### Full sample doc (`docs/github-markdown-samples.md`, 936 lines)
+
+| Run | Peak RSS (KiB) | Peak RSS (MiB) | Elapsed |
+|-----|---------------:|---------------:|--------:|
+| 1 (cold) | 191,976 | 187.5 | 0.41s |
+| 2 (warm) | 191,848 | 187.4 | 0.39s |
+| 3 (warm) | 191,240 | 186.8 | 0.36s |
+
+The sample doc's math/emoji/mermaid content pulls in additional codepoints
+beyond the default set (e.g. `∫ ∑ √ π ± ×` from LaTeX math synthesis, `❤ ⚠`
+from emoji shortcodes), so `ensureGlyphs` performs exactly one atlas rebuild
+per tab load, growing the loaded set past the default 303 — but nowhere
+near the old 2,135, since only the codepoints actually used are added.
+
+### BEFORE vs AFTER comparison (avg of 3 runs)
+
+| Fixture | BEFORE (KiB) | AFTER (KiB) | Delta | Delta % |
+|---------|-------------:|------------:|------:|--------:|
+| One-line file | 199,185 | 189,611 | -9,575 KiB (-9.35 MiB) | -4.81% |
+| Full sample doc | 201,545 | 191,688 | -9,857 KiB (-9.63 MiB) | -4.89% |
+
+**Warm startup:** AFTER warm elapsed (0.34-0.39s) is equal to or faster
+than BEFORE warm elapsed (0.37-0.44s) for both fixtures — not regressed,
+mildly improved. The one-line cold run (1.49s) is an outlier from this
+being the very first process launch after a fresh build with a cold OS
+page cache for the new binary; it is not representative of steady-state
+startup and is excluded from the regression judgment (the same caveat
+documented above under "Take the **first** invocation... as 'cold'").
+
+### Target assessment: **materially reduced, aspirational `<100MB`/`<80MB` target not reached**
+
+- One-line idle peak RSS dropped ~9.4MB (~4.8%), from ~194.5MB to ~185.2MB.
+  This is a real, measurable, material reduction directly attributable to
+  the lazy-atlas work (eager bake shrank from 2,135 to 303 codepoints x 5
+  variants), and warm startup is not regressed.
+- The reduction is smaller than the ~15-20MB the plan estimated from the
+  Task 1 isolation experiment, because that experiment's "reduced" config
+  was ASCII-only (95 codepoints), while the actual eager default per the
+  issue's own spec is larger — Basic Latin + Latin-1 + General Punctuation
+  (303 codepoints). The measured ~9.4MB sits consistently between the
+  ASCII-only floor (95cp -> ~180.9MB) and the full-atlas baseline (2,135cp
+  -> ~194.5MB), scaling roughly with codepoint count as expected.
+- The issue's `<100MB` (ideally `<80MB`) target is **not reached**: idle
+  peak RSS is still ~185-187MB. This was flagged as a likely outcome during
+  planning (see "Go/no-go verdict" above) — the ~181MB ASCII-only floor
+  measured in Task 1 is fixed cost from raylib window creation, the
+  OpenGL/GLX context, and base runtime/allocator overhead, none of which
+  this issue's font-atlas work touches. Closing the remaining gap to
+  `<100MB` would require a separate investigation into that non-font floor
+  and is out of scope for issue #77.
+
+## Glyph coverage verification (no missing-glyph regression)
+
+To verify the tiered loading introduced no missing-glyph regression vs the
+pre-issue-77 baseline, two checks were run against both the AFTER binary
+(commit `2c9ac05`) and a BEFORE binary built from commit `3d842d2^`
+(`9e073de`, the last commit before any issue-77 work, built in a scratch
+`git worktree` with `deps/cmark-gfm` copied in since submodules aren't
+auto-initialized in a fresh worktree checkout):
+
+1. **Targeted glyph-category check** — a small doc exercising every
+   category named in the issue's acceptance criteria (Greek, arrows, math
+   operators, dingbats, ligatures, currency, plus misc symbols, geometric
+   shapes, and superscripts/subscripts) was rendered with `--full-document`
+   on both binaries and diffed pixel-for-pixel. Result: **identical**
+   (a 14x1px anti-aliasing difference in one circled-digit dingbat glyph,
+   well below any visible threshold). Every category renders correctly on
+   both, confirming lazy loading preserves full BMP coverage.
+
+2. **Full sample doc diff** — `docs/github-markdown-samples.md` was
+   rendered full-document on both binaries (1400x22325px) and diffed.
+   Result: 1,391 differing pixels out of ~31.3 million (0.004%), confined
+   to two regions: the GFM alert icons and the emoji-shortcode section.
+   In both regions, the *only* difference is that codepoints outside the
+   Unicode Basic Multilingual Plane (e.g. emoji shortcodes that expand to
+   supplementary-plane codepoints like `:fire:`/`:rocket:`/`:tada:`, and a
+   couple of alert-type icons) render as a `?` placeholder glyph in BEFORE
+   and as blank space in AFTER. These codepoints were **never** in either
+   codepoint table — the pre-issue-77 `codepoints` list (`unicode_codepoints.zig`
+   at `3d842d2^`) tops out at `0xFFFD`, same as today's eager+lazy union —
+   so this is a pre-existing gap in both builds, not a new regression. No
+   glyph that rendered as a real character in BEFORE is blank in AFTER;
+   only the *fallback indicator* for already-unsupported codepoints changed
+   from `?` to blank, which is a raylib font-fallback cosmetic side effect
+   of the atlas being assembled via `unloadFonts`+`loadFontEx` rebuilds
+   instead of a single upfront load, not a functional regression.
+
+**Verdict:** no missing-glyph regression for any of the issue's named
+categories (Greek, arrows, math operators, dingbats, ligatures, currency).
+Supplementary-plane emoji remain unsupported exactly as before — out of
+scope for issue #77, which only targets the BMP ranges enumerated in
+`unicode_codepoints.zig`.

--- a/src/app.zig
+++ b/src/app.zig
@@ -252,11 +252,14 @@ pub const App = struct {
     /// baked them (which would permanently block a retry, since `LoadedSet`
     /// growth is otherwise one-way).
     ///
-    /// No-op (aside from recording growth) if fonts have not been loaded yet
-    /// (`self.fonts == null` / `loadFonts` not yet called) -- there is no
-    /// atlas to fall out of sync with, so growth is committed immediately.
-    /// The eventual `loadFonts` call will re-seed `loaded_codepoints` from
-    /// `default_codepoints`.
+    /// Total no-op if `loadFonts` has never run (`self.loaded_codepoints ==
+    /// null`): nothing is baked and nothing is recorded, since there is no
+    /// default set yet to grow. The eventual `loadFonts` call seeds
+    /// `loaded_codepoints` from `default_codepoints` on its own.
+    ///
+    /// If `loaded_codepoints` exists but `self.fonts` is `null` (fonts were
+    /// unloaded without a reload), growth is committed immediately with no
+    /// atlas rebuild -- there is no atlas to fall out of sync with.
     pub fn ensureGlyphs(self: *App, codepoints: []const i32) !void {
         const set = if (self.loaded_codepoints) |*s| s else return;
 

--- a/src/app.zig
+++ b/src/app.zig
@@ -260,12 +260,36 @@ pub const App = struct {
     /// If `loaded_codepoints` exists but `self.fonts` is `null` (fonts were
     /// unloaded without a reload), growth is committed immediately with no
     /// atlas rebuild -- there is no atlas to fall out of sync with.
-    pub fn ensureGlyphs(self: *App, codepoints: []const i32) !void {
-        const set = if (self.loaded_codepoints) |*s| s else return;
+    ///
+    /// Returns `true` if `codepoints` contained anything not already
+    /// loaded (growth was recorded, and the atlas was rebuilt if `fonts`
+    /// exists), `false` if every codepoint was already loaded. Callers that
+    /// derive layout metrics from the atlas (e.g. `measureTextEx`) should
+    /// re-layout when this returns `true`; high-frequency callers (e.g. one
+    /// per keystroke) can rely on the cheap containment check below to make
+    /// the common all-already-loaded case a fast no-op.
+    pub fn ensureGlyphs(self: *App, codepoints: []const i32) !bool {
+        const set = if (self.loaded_codepoints) |*s| s else return false;
+
+        // Cheap pre-check: skip the hashmap clone below entirely when every
+        // codepoint is already loaded, which is the common case for
+        // high-frequency callers like per-keystroke editor/search/command
+        // input scanning ASCII text against the eager default set.
+        var any_new = false;
+        for (codepoints) |cp| {
+            if (!set.contains(cp)) {
+                any_new = true;
+                break;
+            }
+        }
+        if (!any_new) return false;
 
         if (self.fonts == null) {
-            for (codepoints) |cp| _ = try set.add(cp);
-            return;
+            var grew = false;
+            for (codepoints) |cp| {
+                if (try set.add(cp)) grew = true;
+            }
+            return grew;
         }
 
         // Stage growth in a scratch copy so `set` (self.loaded_codepoints)
@@ -278,7 +302,7 @@ pub const App = struct {
             const result = try staged.getOrPut(cp);
             if (!result.found_existing) grew = true;
         }
-        if (!grew) return;
+        if (!grew) return false;
 
         const expanded = try self.allocator.alloc(i32, staged.count());
         defer self.allocator.free(expanded);
@@ -300,6 +324,8 @@ pub const App = struct {
         // safe to record these codepoints as loaded.
         set.map.deinit();
         set.map = staged.move();
+
+        return true;
     }
 
     // =========================================================================
@@ -346,6 +372,11 @@ pub const App = struct {
                 std.log.err("Failed to layout document: {}", .{err});
             };
         }
+
+        // `path` is scanned alongside `content` since it becomes the tab
+        // title (drawn in the tab bar with the same font atlas) and is
+        // not itself part of the markdown source.
+        self.ensureGlyphsForTab(tab, &.{ content, path });
 
         // Restore saved scroll position if available
         if (self.scroll_store) |store| {
@@ -457,6 +488,119 @@ pub const App = struct {
         const tab = self.activeTab() orelse return;
         try tab.loadMarkdown(text);
         self.relayoutActiveTab();
+        self.ensureGlyphsForTab(tab, &.{text});
+    }
+
+    /// Collect every codepoint needed to render `tab`'s current layout tree
+    /// as the union of a raw UTF-8 scan of `sources` and a walk of the
+    /// tree's text runs, then `ensureGlyphs` them and relayout once if the
+    /// atlas grew -- mirroring the existing double-relayout pattern in
+    /// `newTabWithFile` (relayout, then relayout again after restoring
+    /// details state) so the next `measureTextEx` call sees a fully
+    /// populated atlas rather than a stale one with missing glyphs.
+    ///
+    /// `sources` is the in-hand markdown source buffer (and, for a freshly
+    /// opened file, its path -- the tab title is drawn with the same font
+    /// atlas but is not itself part of the source). It alone covers prose,
+    /// code, tables, headings/ToC, and all Mermaid node/edge/title labels,
+    /// since Mermaid labels are literal text inside the fenced source. The
+    /// text-run walk is needed only for glyphs synthesized purely during
+    /// layout with no literal representation in the source (e.g. math
+    /// symbols rendered from LaTeX).
+    ///
+    /// No-op if `tab` has no layout tree yet (fonts not loaded, or layout
+    /// failed) -- there is nothing to scan or relayout.
+    fn ensureGlyphsForTab(self: *App, tab: *Tab, sources: []const []const u8) void {
+        const tree = if (tab.layout_tree) |*t| t else return;
+
+        var set = std.AutoHashMap(i32, void).init(self.allocator);
+        defer set.deinit();
+
+        for (sources) |source| {
+            unicode_codepoints.addUtf8Codepoints(&set, source) catch |err| {
+                std.log.err("Failed to scan codepoints from source: {}", .{err});
+                return;
+            };
+        }
+        for (tree.nodes.items) |node| {
+            for (node.text_runs.items) |run| {
+                unicode_codepoints.addUtf8Codepoints(&set, run.text) catch |err| {
+                    std.log.err("Failed to scan codepoints from text run: {}", .{err});
+                    return;
+                };
+            }
+        }
+
+        var codepoints = std.ArrayList(i32).initCapacity(self.allocator, set.count()) catch |err| {
+            std.log.err("Failed to collect codepoints: {}", .{err});
+            return;
+        };
+        defer codepoints.deinit();
+        var it = set.keyIterator();
+        while (it.next()) |key| codepoints.appendAssumeCapacity(key.*);
+
+        const grew = self.ensureGlyphs(codepoints.items) catch |err| {
+            std.log.err("Failed to ensure glyphs: {}", .{err});
+            return;
+        };
+        if (!grew) return;
+
+        if (self.fonts) |*f| {
+            tab.relayout(self.theme, f, self.computeLayoutWidth(), self.computeContentYOffset(), self.computeContentLeftOffset(), self.show_line_numbers, self.is_dark) catch |err| {
+                std.log.err("Failed to relayout after glyph load: {}", .{err});
+            };
+        }
+    }
+
+    /// Runtime hook: ensure a single freshly-typed or pasted codepoint is
+    /// loaded, growth-only and idempotent via `ensureGlyphs`'s containment
+    /// pre-check. Called from the editor, search, and command-palette input
+    /// handlers as each character arrives from `rl.getCharPressed()` (which
+    /// already yields a decoded Unicode codepoint, not raw bytes, so no
+    /// UTF-8 scan is needed here). ASCII input -- the only input search and
+    /// the command bar currently accept -- is a cheap no-op: those
+    /// codepoints are already in `default_codepoints`.
+    ///
+    /// No relayout here -- for the editor, the existing `edit_version`-driven
+    /// live-preview reparse (`Tab.previewNeedsUpdate`, checked every frame in
+    /// `update()`) re-measures against the atlas on the same frame, since
+    /// this hook runs before that check. Search and command-bar text isn't
+    /// laid out through the document atlas path at all.
+    fn ensureGlyphForChar(self: *App, codepoint: i32) void {
+        _ = self.ensureGlyphs(&.{codepoint}) catch |err| {
+            std.log.err("Failed to ensure glyph for typed character: {}", .{err});
+        };
+    }
+
+    /// Runtime hook: scan `inserted` (the bytes just added, not the full
+    /// buffer) for codepoints not yet loaded and load them growth-only via
+    /// `ensureGlyphs`. Used for editor paste, where the inserted text
+    /// arrives as a raw UTF-8 clipboard byte slice rather than one
+    /// codepoint at a time. See `ensureGlyphForChar` for why no relayout is
+    /// triggered here.
+    fn ensureGlyphsForBytes(self: *App, inserted: []const u8) void {
+        if (inserted.len == 0) return;
+
+        var set = std.AutoHashMap(i32, void).init(self.allocator);
+        defer set.deinit();
+        unicode_codepoints.addUtf8Codepoints(&set, inserted) catch |err| {
+            std.log.err("Failed to scan inserted codepoints: {}", .{err});
+            return;
+        };
+        if (set.count() == 0) return;
+
+        const codepoints = self.allocator.alloc(i32, set.count()) catch |err| {
+            std.log.err("Failed to collect inserted codepoints: {}", .{err});
+            return;
+        };
+        defer self.allocator.free(codepoints);
+        var i: usize = 0;
+        var it = set.keyIterator();
+        while (it.next()) |key| : (i += 1) codepoints[i] = key.*;
+
+        _ = self.ensureGlyphs(codepoints) catch |err| {
+            std.log.err("Failed to ensure glyphs for inserted text: {}", .{err});
+        };
     }
 
     fn relayoutActiveTab(self: *App) void {
@@ -768,9 +912,11 @@ pub const App = struct {
             } else if (rl.isKeyPressed(.v)) {
                 const clipboard: []const u8 = rl.getClipboardText();
                 if (clipboard.len > 0) {
-                    editor.replaceSelection(clipboard) catch |err| {
+                    if (editor.replaceSelection(clipboard)) |_| {
+                        self.ensureGlyphsForBytes(clipboard);
+                    } else |err| {
                         std.log.err("Editor paste failed: {}", .{err});
-                    };
+                    }
                 }
                 handled = true;
             } else if (rl.isKeyPressed(.z)) {
@@ -915,9 +1061,11 @@ pub const App = struct {
                         std.log.err("Editor delete selection failed: {}", .{err});
                     };
                 }
-                editor.insertChar(@intCast(char)) catch |err| {
+                if (editor.insertChar(@intCast(char))) |_| {
+                    self.ensureGlyphForChar(char);
+                } else |err| {
                     std.log.err("Editor insert failed: {}", .{err});
-                };
+                }
             }
             char = rl.getCharPressed();
         }
@@ -2089,6 +2237,11 @@ pub const App = struct {
         var char = rl.getCharPressed();
         while (char > 0) {
             if (char >= 32 and char < 127) {
+                // Search input is restricted to printable ASCII above, which
+                // is already in `default_codepoints` -- this is a defensive
+                // no-op today, kept for consistency with the other input
+                // surfaces in case that restriction is ever loosened.
+                self.ensureGlyphForChar(char);
                 if (tab.search.appendChar(@intCast(char))) {
                     self.executeSearch();
                 }
@@ -2152,6 +2305,10 @@ pub const App = struct {
         var char = rl.getCharPressed();
         while (char > 0) {
             if (char >= '0' and char <= '9') {
+                // Digits are already in `default_codepoints` -- a defensive
+                // no-op today, kept for consistency with the other input
+                // surfaces (see updateSearch).
+                self.ensureGlyphForChar(char);
                 _ = tab.command.appendChar(@intCast(char));
             }
             char = rl.getCharPressed();
@@ -2958,8 +3115,9 @@ test "App.ensureGlyphs with only already-loaded codepoints triggers no rebuild" 
     const before_count = app.loaded_codepoints.?.map.count();
 
     // 'A', 'a', em dash -- all within default_codepoints already.
-    try app.ensureGlyphs(&.{ 0x41, 0x61, 0x2014 });
+    const grew = try app.ensureGlyphs(&.{ 0x41, 0x61, 0x2014 });
 
+    try testing.expect(!grew);
     try testing.expectEqual(before_count, app.loaded_codepoints.?.map.count());
     // No rebuild was attempted (would have crashed without a GL context).
     try testing.expectEqual(@as(?Fonts, null), app.fonts);
@@ -2975,7 +3133,8 @@ test "App.ensureGlyphs grows the set for a new codepoint range and contains refl
         try testing.expect(!app.loaded_codepoints.?.contains(cp));
     }
 
-    try app.ensureGlyphs(greek_range);
+    const grew = try app.ensureGlyphs(greek_range);
+    try testing.expect(grew);
 
     for (greek_range) |cp| {
         try testing.expect(app.loaded_codepoints.?.contains(cp));
@@ -2989,13 +3148,61 @@ test "App.ensureGlyphs is idempotent across repeated calls with the same codepoi
 
     const arrow: i32 = 0x2192; // rightwards arrow -- remainder pool
 
-    try app.ensureGlyphs(&.{arrow});
+    const grew_first = try app.ensureGlyphs(&.{arrow});
+    try testing.expect(grew_first);
     const count_after_first = app.loaded_codepoints.?.map.count();
     try testing.expect(app.loaded_codepoints.?.contains(arrow));
 
-    try app.ensureGlyphs(&.{arrow});
-    try app.ensureGlyphs(&.{arrow});
+    const grew_second = try app.ensureGlyphs(&.{arrow});
+    const grew_third = try app.ensureGlyphs(&.{arrow});
+    try testing.expect(!grew_second);
+    try testing.expect(!grew_third);
 
     try testing.expectEqual(count_after_first, app.loaded_codepoints.?.map.count());
     try testing.expect(app.loaded_codepoints.?.contains(arrow));
+}
+
+test "App.ensureGlyphsForTab unions raw-source scan (incl. mermaid fence) with text-run walk (synthesized math), growing the loaded set" {
+    const lt = @import("layout/layout_types.zig");
+
+    var app = App.init(testing.allocator);
+    defer app.deinit();
+    app.loaded_codepoints = try unicode_codepoints.LoadedSet.init(testing.allocator);
+
+    var tab = Tab.init(testing.allocator);
+    defer tab.deinit();
+
+    // "Prose with a Greek letter: α." + a mermaid flowchart fence whose node
+    // label is "β" -- mermaid labels are drawn from the parsed diagram
+    // model, not text_runs, so β can only be discovered by the raw-source
+    // scan (this simulates task 4's requirement that mermaid node/edge
+    // labels be captured from the fenced source, not the layout tree).
+    const source = "# Heading\n\nProse with a Greek letter: \xCE\xB1.\n\n```mermaid\nflowchart TD\n    A[\xCE\xB2] --> B[end]\n```\n";
+    try tab.loadMarkdown(source);
+
+    // Simulate a layout tree containing a synthesized math glyph ("π",
+    // U+03C0) with no literal representation anywhere in `source` -- this
+    // is what a real LaTeX math layout pass produces, and it can only be
+    // discovered by the text-run walk.
+    var tree = lt.LayoutTree.init(testing.allocator);
+    var math_node = lt.LayoutNode.init(testing.allocator, .text_block);
+    try math_node.text_runs.append(.{
+        .text = "\xCF\x80", // π
+        .style = .{ .font_size = 16, .color = .{ .r = 0, .g = 0, .b = 0, .a = 255 } },
+        .rect = .{ .x = 0, .y = 0, .width = 0, .height = 0 },
+    });
+    try tree.nodes.append(math_node);
+    tab.layout_tree = tree;
+
+    // Sanity: none of the three glyphs are loaded yet -- all three live in
+    // the lazy remainder pool, not the eager default set.
+    try testing.expect(!app.loaded_codepoints.?.contains(0x03B1)); // α
+    try testing.expect(!app.loaded_codepoints.?.contains(0x03B2)); // β
+    try testing.expect(!app.loaded_codepoints.?.contains(0x03C0)); // π
+
+    app.ensureGlyphsForTab(&tab, &.{source});
+
+    try testing.expect(app.loaded_codepoints.?.contains(0x03B1)); // prose (raw-source scan)
+    try testing.expect(app.loaded_codepoints.?.contains(0x03B2)); // mermaid label (raw-source scan)
+    try testing.expect(app.loaded_codepoints.?.contains(0x03C0)); // synthesized math (text-run walk)
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -72,6 +72,10 @@ pub const App = struct {
     theme: *const Theme,
     is_dark: bool,
     fonts: ?Fonts,
+    /// Owned. Accumulating record of which codepoints have been baked into
+    /// the current `fonts` atlases. Seeded with `unicode_codepoints.default_codepoints`
+    /// by `loadFonts`; grown by `ensureGlyphs`. Never shrinks.
+    loaded_codepoints: ?unicode_codepoints.LoadedSet = null,
     viewport: Viewport,
     menu_bar: MenuBar,
     /// Owned custom theme loaded from JSON (null if using built-in themes)
@@ -170,7 +174,12 @@ pub const App = struct {
         .{ "mono", "fonts/JetBrainsMono-Regular.ttf" },
     };
 
-    pub fn loadFonts(self: *App) !void {
+    /// Bake all 5 font variants at the fixed 32px size, using `codepoints` as
+    /// the glyph set for every atlas, and assign the result to `self.fonts`.
+    /// Callers must ensure any previously loaded fonts were unloaded first
+    /// (see `unloadFonts`) -- this always builds a fresh set of atlases and
+    /// unconditionally overwrites `self.fonts`.
+    fn loadFontVariants(self: *App, codepoints: []const i32) !void {
         const size = 32;
         var fonts: Fonts = undefined;
         var loaded_count: usize = 0;
@@ -196,11 +205,24 @@ pub const App = struct {
 
             // Safety: raylib only reads from the codepoints array; @constCast needed
             // because raylib-zig's loadFontEx signature takes ?[]i32 (mutable).
-            @field(fonts, entry[0]) = try rl.loadFontEx(path, size, @constCast(&unicode_codepoints.default_codepoints));
+            @field(fonts, entry[0]) = try rl.loadFontEx(path, size, @constCast(codepoints));
             rl.setTextureFilter(@field(fonts, entry[0]).texture, .bilinear);
             loaded_count += 1;
         }
         self.fonts = fonts;
+    }
+
+    /// Load all 5 font variants, baking only the eager default codepoint set
+    /// (`unicode_codepoints.default_codepoints`). Seeds `self.loaded_codepoints`
+    /// to track that set. Additional codepoints are loaded on demand via
+    /// `ensureGlyphs`.
+    pub fn loadFonts(self: *App) !void {
+        var loaded_set = try unicode_codepoints.LoadedSet.init(self.allocator);
+        errdefer loaded_set.deinit();
+
+        try self.loadFontVariants(&unicode_codepoints.default_codepoints);
+
+        self.loaded_codepoints = loaded_set;
     }
 
     pub fn unloadFonts(self: *App) void {
@@ -209,6 +231,40 @@ pub const App = struct {
             rl.unloadFont(@field(fonts, entry[0]));
         }
         self.fonts = null;
+    }
+
+    /// Ensure every codepoint in `codepoints` has a baked glyph in all 5 font
+    /// atlases. Codepoints already loaded (from the eager default set or a
+    /// prior `ensureGlyphs` call) are skipped -- this is a no-op if every
+    /// codepoint in `codepoints` is already loaded.
+    ///
+    /// If any codepoint is new, all 5 font variants are rebuilt exactly once
+    /// via `unloadFonts` + `loadFontVariants` with the expanded codepoint
+    /// set -- one atlas per font, never proliferating textures.
+    ///
+    /// No-op (aside from recording growth) if fonts have not been loaded yet
+    /// (`self.fonts == null` / `loadFonts` not yet called) -- there is
+    /// nothing to rebuild. The eventual `loadFonts` call will re-seed
+    /// `loaded_codepoints` from `default_codepoints`.
+    pub fn ensureGlyphs(self: *App, codepoints: []const i32) !void {
+        const set = if (self.loaded_codepoints) |*s| s else return;
+
+        var grew = false;
+        for (codepoints) |cp| {
+            if (try set.add(cp)) grew = true;
+        }
+        if (!grew or self.fonts == null) return;
+
+        const expanded = try self.allocator.alloc(i32, set.map.count());
+        defer self.allocator.free(expanded);
+        var it = set.map.keyIterator();
+        var i: usize = 0;
+        while (it.next()) |key| : (i += 1) {
+            expanded[i] = key.*;
+        }
+
+        self.unloadFonts();
+        try self.loadFontVariants(expanded);
     }
 
     // =========================================================================
@@ -2112,6 +2168,9 @@ pub const App = struct {
         }
         self.tabs.deinit();
         self.toc_sidebar.deinit();
+        if (self.loaded_codepoints) |*set| {
+            set.deinit();
+        }
     }
 
     /// Save the scroll position for a tab at the given index.
@@ -2843,4 +2902,65 @@ test "App.isEditorVisible returns true when editor is open and mode is split" {
     try tab.toggleEditMode();
     app.view_mode = .split;
     try testing.expect(app.isEditorVisible());
+}
+
+// =========================================================================
+// App.ensureGlyphs
+//
+// These tests exercise `loaded_codepoints` growth tracking directly (via a
+// manually-seeded `LoadedSet`, bypassing `loadFonts`/`rl.loadFontEx`) rather
+// than through a real font atlas rebuild -- the test binary has no OpenGL
+// context (no window is ever created), so `self.fonts` stays `null` and the
+// atlas-rebuild branch in `ensureGlyphs` is never taken. This still fully
+// covers the growth-tracking contract that `ensureGlyphs` is responsible for.
+// =========================================================================
+
+test "App.ensureGlyphs with only already-loaded codepoints triggers no rebuild" {
+    var app = App.init(testing.allocator);
+    defer app.deinit();
+    app.loaded_codepoints = try unicode_codepoints.LoadedSet.init(testing.allocator);
+
+    const before_count = app.loaded_codepoints.?.map.count();
+
+    // 'A', 'a', em dash -- all within default_codepoints already.
+    try app.ensureGlyphs(&.{ 0x41, 0x61, 0x2014 });
+
+    try testing.expectEqual(before_count, app.loaded_codepoints.?.map.count());
+    // No rebuild was attempted (would have crashed without a GL context).
+    try testing.expectEqual(@as(?Fonts, null), app.fonts);
+}
+
+test "App.ensureGlyphs grows the set for a new codepoint range and contains reflects it" {
+    var app = App.init(testing.allocator);
+    defer app.deinit();
+    app.loaded_codepoints = try unicode_codepoints.LoadedSet.init(testing.allocator);
+
+    const greek_range = unicode_codepoints.remainder_codepoints[0..5];
+    for (greek_range) |cp| {
+        try testing.expect(!app.loaded_codepoints.?.contains(cp));
+    }
+
+    try app.ensureGlyphs(greek_range);
+
+    for (greek_range) |cp| {
+        try testing.expect(app.loaded_codepoints.?.contains(cp));
+    }
+}
+
+test "App.ensureGlyphs is idempotent across repeated calls with the same codepoints" {
+    var app = App.init(testing.allocator);
+    defer app.deinit();
+    app.loaded_codepoints = try unicode_codepoints.LoadedSet.init(testing.allocator);
+
+    const arrow: i32 = 0x2192; // rightwards arrow -- remainder pool
+
+    try app.ensureGlyphs(&.{arrow});
+    const count_after_first = app.loaded_codepoints.?.map.count();
+    try testing.expect(app.loaded_codepoints.?.contains(arrow));
+
+    try app.ensureGlyphs(&.{arrow});
+    try app.ensureGlyphs(&.{arrow});
+
+    try testing.expectEqual(count_after_first, app.loaded_codepoints.?.map.count());
+    try testing.expect(app.loaded_codepoints.?.contains(arrow));
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -246,24 +246,40 @@ pub const App = struct {
     /// proliferating textures. The replacement set is fully baked before the
     /// old one is unloaded, so if the rebuild fails (e.g. OOM), the
     /// previously-working atlas in `self.fonts` is left untouched rather than
-    /// torn down.
+    /// torn down. Growth is staged in a scratch copy of `loaded_codepoints`
+    /// and only swapped in after the rebuild succeeds, so a failed rebuild
+    /// never leaves codepoints marked "loaded" when the atlas never actually
+    /// baked them (which would permanently block a retry, since `LoadedSet`
+    /// growth is otherwise one-way).
     ///
     /// No-op (aside from recording growth) if fonts have not been loaded yet
-    /// (`self.fonts == null` / `loadFonts` not yet called) -- there is
-    /// nothing to rebuild. The eventual `loadFonts` call will re-seed
-    /// `loaded_codepoints` from `default_codepoints`.
+    /// (`self.fonts == null` / `loadFonts` not yet called) -- there is no
+    /// atlas to fall out of sync with, so growth is committed immediately.
+    /// The eventual `loadFonts` call will re-seed `loaded_codepoints` from
+    /// `default_codepoints`.
     pub fn ensureGlyphs(self: *App, codepoints: []const i32) !void {
         const set = if (self.loaded_codepoints) |*s| s else return;
 
+        if (self.fonts == null) {
+            for (codepoints) |cp| _ = try set.add(cp);
+            return;
+        }
+
+        // Stage growth in a scratch copy so `set` (self.loaded_codepoints)
+        // is only mutated after the rebuild it describes actually succeeds.
+        var staged = try set.map.clone();
+        defer staged.deinit();
+
         var grew = false;
         for (codepoints) |cp| {
-            if (try set.add(cp)) grew = true;
+            const result = try staged.getOrPut(cp);
+            if (!result.found_existing) grew = true;
         }
-        if (!grew or self.fonts == null) return;
+        if (!grew) return;
 
-        const expanded = try self.allocator.alloc(i32, set.map.count());
+        const expanded = try self.allocator.alloc(i32, staged.count());
         defer self.allocator.free(expanded);
-        var it = set.map.keyIterator();
+        var it = staged.keyIterator();
         var i: usize = 0;
         while (it.next()) |key| : (i += 1) {
             expanded[i] = key.*;
@@ -271,10 +287,16 @@ pub const App = struct {
 
         // Build the expanded atlas before tearing down the old one -- a
         // failure here (e.g. OOM baking a larger atlas) must not leave
-        // self.fonts null.
+        // self.fonts null, and must not commit `staged` into
+        // loaded_codepoints (the `try` below propagates before that swap).
         const new_fonts = try self.loadFontVariants(expanded);
         self.unloadFonts();
         self.fonts = new_fonts;
+
+        // Only now commit the growth: the atlas rebuild succeeded, so it's
+        // safe to record these codepoints as loaded.
+        set.map.deinit();
+        set.map = staged.move();
     }
 
     // =========================================================================

--- a/src/app.zig
+++ b/src/app.zig
@@ -175,11 +175,13 @@ pub const App = struct {
     };
 
     /// Bake all 5 font variants at the fixed 32px size, using `codepoints` as
-    /// the glyph set for every atlas, and assign the result to `self.fonts`.
-    /// Callers must ensure any previously loaded fonts were unloaded first
-    /// (see `unloadFonts`) -- this always builds a fresh set of atlases and
-    /// unconditionally overwrites `self.fonts`.
-    fn loadFontVariants(self: *App, codepoints: []const i32) !void {
+    /// the glyph set for every atlas, and return the result. Does not touch
+    /// `self.fonts` -- callers decide when (and whether) to swap it in, so a
+    /// failed rebuild never leaves `self.fonts` null with no atlas to fall
+    /// back on. On failure, any variants already baked in this call are
+    /// unloaded via `errdefer`; anything in `self.fonts` from a prior call is
+    /// untouched.
+    fn loadFontVariants(self: *App, codepoints: []const i32) !Fonts {
         const size = 32;
         var fonts: Fonts = undefined;
         var loaded_count: usize = 0;
@@ -209,19 +211,20 @@ pub const App = struct {
             rl.setTextureFilter(@field(fonts, entry[0]).texture, .bilinear);
             loaded_count += 1;
         }
-        self.fonts = fonts;
+        return fonts;
     }
 
     /// Load all 5 font variants, baking only the eager default codepoint set
     /// (`unicode_codepoints.default_codepoints`). Seeds `self.loaded_codepoints`
-    /// to track that set. Additional codepoints are loaded on demand via
-    /// `ensureGlyphs`.
+    /// to track that set, freeing any prior value first. Additional codepoints
+    /// are loaded on demand via `ensureGlyphs`.
     pub fn loadFonts(self: *App) !void {
         var loaded_set = try unicode_codepoints.LoadedSet.init(self.allocator);
         errdefer loaded_set.deinit();
 
-        try self.loadFontVariants(&unicode_codepoints.default_codepoints);
+        self.fonts = try self.loadFontVariants(&unicode_codepoints.default_codepoints);
 
+        if (self.loaded_codepoints) |*old| old.deinit();
         self.loaded_codepoints = loaded_set;
     }
 
@@ -239,8 +242,11 @@ pub const App = struct {
     /// codepoint in `codepoints` is already loaded.
     ///
     /// If any codepoint is new, all 5 font variants are rebuilt exactly once
-    /// via `unloadFonts` + `loadFontVariants` with the expanded codepoint
-    /// set -- one atlas per font, never proliferating textures.
+    /// with the expanded codepoint set -- one atlas per font, never
+    /// proliferating textures. The replacement set is fully baked before the
+    /// old one is unloaded, so if the rebuild fails (e.g. OOM), the
+    /// previously-working atlas in `self.fonts` is left untouched rather than
+    /// torn down.
     ///
     /// No-op (aside from recording growth) if fonts have not been loaded yet
     /// (`self.fonts == null` / `loadFonts` not yet called) -- there is
@@ -263,8 +269,12 @@ pub const App = struct {
             expanded[i] = key.*;
         }
 
+        // Build the expanded atlas before tearing down the old one -- a
+        // failure here (e.g. OOM baking a larger atlas) must not leave
+        // self.fonts null.
+        const new_fonts = try self.loadFontVariants(expanded);
         self.unloadFonts();
-        try self.loadFontVariants(expanded);
+        self.fonts = new_fonts;
     }
 
     // =========================================================================

--- a/src/app.zig
+++ b/src/app.zig
@@ -196,7 +196,7 @@ pub const App = struct {
 
             // Safety: raylib only reads from the codepoints array; @constCast needed
             // because raylib-zig's loadFontEx signature takes ?[]i32 (mutable).
-            @field(fonts, entry[0]) = try rl.loadFontEx(path, size, @constCast(&unicode_codepoints.codepoints));
+            @field(fonts, entry[0]) = try rl.loadFontEx(path, size, @constCast(&unicode_codepoints.default_codepoints));
             rl.setTextureFilter(@field(fonts, entry[0]).texture, .bilinear);
             loaded_count += 1;
         }

--- a/src/unicode_codepoints.zig
+++ b/src/unicode_codepoints.zig
@@ -1,16 +1,25 @@
 const std = @import("std");
 
 /// Unicode codepoint ranges to load for font rendering.
-/// Covers common Latin text, punctuation, symbols, and mathematical operators.
 const Range = struct { start: i32, end: i32 };
 
-const ranges = [_]Range{
+/// Eager default set: loaded unconditionally into every font atlas at startup.
+/// Covers the codepoints virtually every document needs on first frame —
+/// Basic Latin, Latin-1 accented characters/symbols, and common punctuation
+/// (em dash, curly quotes, ellipsis).
+const default_ranges = [_]Range{
     .{ .start = 0x0020, .end = 0x007E }, // Basic Latin (space through tilde)
     .{ .start = 0x00A0, .end = 0x00FF }, // Latin-1 Supplement (non-breaking space, accented chars, symbols)
+    .{ .start = 0x2000, .end = 0x206F }, // General Punctuation (em dash, curly quotes, ellipsis, etc.)
+};
+
+/// Lazy remainder pool: not loaded at startup. Loaded on demand (via
+/// `App.ensureGlyphs`) the first time a document or user input actually
+/// needs one of these codepoints.
+const remainder_ranges = [_]Range{
     .{ .start = 0x0100, .end = 0x017F }, // Latin Extended-A (Eastern European)
     .{ .start = 0x0180, .end = 0x024F }, // Latin Extended-B
     .{ .start = 0x0370, .end = 0x03FF }, // Greek and Coptic (α β γ δ π θ σ etc. — required for math)
-    .{ .start = 0x2000, .end = 0x206F }, // General Punctuation (em dash, curly quotes, ellipsis, etc.)
     .{ .start = 0x2070, .end = 0x209F }, // Superscripts and Subscripts
     .{ .start = 0x20A0, .end = 0x20CF }, // Currency Symbols
     .{ .start = 0x2100, .end = 0x214F }, // Letterlike Symbols
@@ -24,18 +33,19 @@ const ranges = [_]Range{
     .{ .start = 0xFFFD, .end = 0xFFFD }, // Replacement character
 };
 
-const total_count = blk: {
+/// Number of codepoints covered by `ranges`, computed at comptime.
+fn countOf(comptime ranges: []const Range) usize {
     var count: usize = 0;
     for (ranges) |r| {
         count += @as(usize, @intCast(r.end - r.start + 1));
     }
-    break :blk count;
-};
+    return count;
+}
 
-/// Flat array of all codepoints to load, built at comptime.
-pub const codepoints: [total_count]i32 = blk: {
+/// Flatten `ranges` into a sorted array of individual codepoints, built at comptime.
+fn buildCodepoints(comptime ranges: []const Range, comptime count: usize) [count]i32 {
     @setEvalBranchQuota(10_000);
-    var arr: [total_count]i32 = undefined;
+    var arr: [count]i32 = undefined;
     var i: usize = 0;
     for (ranges) |r| {
         var cp = r.start;
@@ -44,79 +54,191 @@ pub const codepoints: [total_count]i32 = blk: {
             i += 1;
         }
     }
-    break :blk arr;
+    return arr;
+}
+
+const default_count = countOf(&default_ranges);
+const remainder_count = countOf(&remainder_ranges);
+
+/// Codepoints loaded eagerly into every font atlas at startup.
+pub const default_codepoints: [default_count]i32 = buildCodepoints(&default_ranges, default_count);
+
+/// Codepoints loaded lazily, on demand, when first needed.
+pub const remainder_codepoints: [remainder_count]i32 = buildCodepoints(&remainder_ranges, remainder_count);
+
+/// Growth-only set of codepoints currently loaded into a font's glyph atlas.
+///
+/// Never shrinks: codepoints are only ever added, mirroring the one-way
+/// rebuild-larger-never-smaller nature of atlas expansion (see
+/// `App.ensureGlyphs`). Seeded with `default_codepoints` on `init`.
+pub const LoadedSet = struct {
+    map: std.AutoHashMap(i32, void),
+
+    /// Create a set pre-seeded with the eager default codepoints.
+    pub fn init(allocator: std.mem.Allocator) !LoadedSet {
+        var map = std.AutoHashMap(i32, void).init(allocator);
+        errdefer map.deinit();
+        try map.ensureTotalCapacity(default_codepoints.len);
+        for (default_codepoints) |cp| {
+            map.putAssumeCapacity(cp, {});
+        }
+        return .{ .map = map };
+    }
+
+    pub fn deinit(self: *LoadedSet) void {
+        self.map.deinit();
+    }
+
+    /// Whether `cp` has already been loaded.
+    pub fn contains(self: *const LoadedSet, cp: i32) bool {
+        return self.map.contains(cp);
+    }
+
+    /// Add `cp` to the set. Returns `true` if it was newly added (the set
+    /// grew) and `false` if it was already present.
+    pub fn add(self: *LoadedSet, cp: i32) !bool {
+        const result = try self.map.getOrPut(cp);
+        return !result.found_existing;
+    }
 };
 
-test "codepoints contains ASCII printable range" {
+test "default codepoints contains ASCII printable range" {
     for (0x20..0x7F) |cp| {
-        try std.testing.expect(contains(@intCast(cp)));
+        try std.testing.expect(containsCp(&default_codepoints, @intCast(cp)));
     }
 }
 
-test "codepoints contains em dash and curly quotes" {
-    try std.testing.expect(contains(0x2014)); // em dash
-    try std.testing.expect(contains(0x2013)); // en dash
-    try std.testing.expect(contains(0x2018)); // left single quote
-    try std.testing.expect(contains(0x2019)); // right single quote
-    try std.testing.expect(contains(0x201C)); // left double quote
-    try std.testing.expect(contains(0x201D)); // right double quote
-    try std.testing.expect(contains(0x2026)); // horizontal ellipsis
+test "default codepoints contains em dash and curly quotes" {
+    try std.testing.expect(containsCp(&default_codepoints, 0x2014)); // em dash
+    try std.testing.expect(containsCp(&default_codepoints, 0x2013)); // en dash
+    try std.testing.expect(containsCp(&default_codepoints, 0x2018)); // left single quote
+    try std.testing.expect(containsCp(&default_codepoints, 0x2019)); // right single quote
+    try std.testing.expect(containsCp(&default_codepoints, 0x201C)); // left double quote
+    try std.testing.expect(containsCp(&default_codepoints, 0x201D)); // right double quote
+    try std.testing.expect(containsCp(&default_codepoints, 0x2026)); // horizontal ellipsis
 }
 
-test "codepoints contains accented Latin characters" {
-    try std.testing.expect(contains(0x00E9)); // é
-    try std.testing.expect(contains(0x00F1)); // ñ
-    try std.testing.expect(contains(0x00FC)); // ü
-    try std.testing.expect(contains(0x00C0)); // À
+test "default codepoints contains accented Latin characters" {
+    try std.testing.expect(containsCp(&default_codepoints, 0x00E9)); // é
+    try std.testing.expect(containsCp(&default_codepoints, 0x00F1)); // ñ
+    try std.testing.expect(containsCp(&default_codepoints, 0x00FC)); // ü
+    try std.testing.expect(containsCp(&default_codepoints, 0x00C0)); // À
 }
 
-test "codepoints contains common symbols" {
-    try std.testing.expect(contains(0x00A9)); // copyright ©
-    try std.testing.expect(contains(0x00AE)); // registered ®
-    try std.testing.expect(contains(0x20AC)); // euro €
-    try std.testing.expect(contains(0x2192)); // rightwards arrow →
-    try std.testing.expect(contains(0x2713)); // check mark ✓
-    try std.testing.expect(contains(0xFFFD)); // replacement character �
+test "default codepoints contains Latin-1 symbols" {
+    try std.testing.expect(containsCp(&default_codepoints, 0x00A9)); // copyright ©
+    try std.testing.expect(containsCp(&default_codepoints, 0x00AE)); // registered ®
+    try std.testing.expect(containsCp(&default_codepoints, 0x00A0)); // non-breaking space
 }
 
-test "codepoints contains Greek letters required for math" {
-    try std.testing.expect(contains(0x03C0)); // π  (pi)
-    try std.testing.expect(contains(0x03B1)); // α  (alpha)
-    try std.testing.expect(contains(0x03B2)); // β  (beta)
-    try std.testing.expect(contains(0x03B3)); // γ  (gamma)
-    try std.testing.expect(contains(0x03B4)); // δ  (delta)
-    try std.testing.expect(contains(0x03B8)); // θ  (theta)
-    try std.testing.expect(contains(0x03C3)); // σ  (sigma)
-    try std.testing.expect(contains(0x03A3)); // Σ  (Sigma — uppercase sum)
-    try std.testing.expect(contains(0x03A0)); // Π  (Pi — uppercase)
-    try std.testing.expect(contains(0x03A9)); // Ω  (Omega)
+test "default codepoints excludes control characters and remainder ranges" {
+    try std.testing.expect(!containsCp(&default_codepoints, 0x0000)); // null
+    try std.testing.expect(!containsCp(&default_codepoints, 0x0019)); // end of C0 control range
+    try std.testing.expect(!containsCp(&default_codepoints, 0x007F)); // DEL
+    try std.testing.expect(!containsCp(&default_codepoints, 0x0080)); // start of C1 control range
+    try std.testing.expect(!containsCp(&default_codepoints, 0x009F)); // end of C1 control range
+    try std.testing.expect(!containsCp(&default_codepoints, 0x0100)); // Latin Extended-A (remainder)
+    try std.testing.expect(!containsCp(&default_codepoints, 0x03C0)); // π (remainder)
+    try std.testing.expect(!containsCp(&default_codepoints, 0x20AC)); // euro (remainder)
+    try std.testing.expect(!containsCp(&default_codepoints, 0x2192)); // rightwards arrow (remainder)
+    try std.testing.expect(!containsCp(&default_codepoints, 0xFFFD)); // replacement character (remainder)
 }
 
-test "codepoints excludes control characters and gaps" {
-    try std.testing.expect(!contains(0x0000)); // null
-    try std.testing.expect(!contains(0x0019)); // end of C0 control range
-    try std.testing.expect(!contains(0x007F)); // DEL
-    try std.testing.expect(!contains(0x0080)); // start of C1 control range
-    try std.testing.expect(!contains(0x009F)); // end of C1 control range
-    try std.testing.expect(!contains(0x0250)); // in gap between Latin Extended-B and Greek
-    try std.testing.expect(!contains(0x036F)); // just before Greek and Coptic block
-    try std.testing.expect(!contains(0x1FFF)); // just before General Punctuation
-    try std.testing.expect(!contains(0x20D0)); // just past Currency Symbols
-    try std.testing.expect(!contains(0x27C0)); // just past Dingbats
-    try std.testing.expect(!contains(0xFB07)); // just past ligatures
-    try std.testing.expect(!contains(0xFFFE)); // just before replacement character
+test "remainder codepoints contains extended Latin and Greek" {
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x0100)); // Ā — Latin Extended-A
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x0180)); // Latin Extended-B
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03C0)); // π (pi)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03B1)); // α (alpha)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03B2)); // β (beta)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03B3)); // γ (gamma)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03B4)); // δ (delta)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03B8)); // θ (theta)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03C3)); // σ (sigma)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03A3)); // Σ (Sigma — uppercase sum)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03A0)); // Π (Pi — uppercase)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x03A9)); // Ω (Omega)
 }
 
-test "total codepoint count matches expected value" {
+test "remainder codepoints contains symbol and technical blocks" {
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2070)); // superscript zero
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x20AC)); // euro €
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2122)); // trademark ™ (letterlike)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2192)); // rightwards arrow →
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2211)); // n-ary summation (math operators)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2318)); // place of interest sign (misc technical)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x25A0)); // black square (geometric shapes)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2600)); // black sun with rays (misc symbols)
+    try std.testing.expect(containsCp(&remainder_codepoints, 0x2713)); // check mark ✓ (dingbats)
+}
+
+test "remainder codepoints contains ligatures and replacement character" {
+    try std.testing.expect(containsCp(&remainder_codepoints, 0xFB00)); // ﬀ ligature
+    try std.testing.expect(containsCp(&remainder_codepoints, 0xFB06)); // ﬆ ligature
+    try std.testing.expect(containsCp(&remainder_codepoints, 0xFFFD)); // replacement character �
+}
+
+test "remainder codepoints excludes control characters and gaps" {
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0x0250)); // gap between Latin Extended-B and Greek
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0x036F)); // just before Greek and Coptic block
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0x1FFF)); // just before General Punctuation
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0x20D0)); // just past Currency Symbols
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0x27C0)); // just past Dingbats
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0xFB07)); // just past ligatures
+    try std.testing.expect(!containsCp(&remainder_codepoints, 0xFFFE)); // just before replacement character
+}
+
+test "default and remainder codepoints do not overlap" {
+    for (default_codepoints) |cp| {
+        try std.testing.expect(!containsCp(&remainder_codepoints, cp));
+    }
+    for (remainder_codepoints) |cp| {
+        try std.testing.expect(!containsCp(&default_codepoints, cp));
+    }
+}
+
+test "default codepoint count matches expected value" {
     // Hardcoded to catch accidental range additions/removals.
-    // Update this value when intentionally changing the ranges.
-    // Greek and Coptic block (0x0370-0x03FF) adds 144 codepoints over previous 1991.
-    try std.testing.expectEqual(@as(usize, 2135), codepoints.len);
+    // Update this value when intentionally changing default_ranges.
+    try std.testing.expectEqual(@as(usize, 303), default_codepoints.len);
+}
+
+test "remainder codepoint count matches expected value" {
+    // Hardcoded to catch accidental range additions/removals.
+    // Update this value when intentionally changing remainder_ranges.
+    try std.testing.expectEqual(@as(usize, 1832), remainder_codepoints.len);
+}
+
+test "LoadedSet is seeded with the default codepoints" {
+    var set = try LoadedSet.init(std.testing.allocator);
+    defer set.deinit();
+    for (default_codepoints) |cp| {
+        try std.testing.expect(set.contains(cp));
+    }
+}
+
+test "LoadedSet does not contain remainder codepoints until added" {
+    var set = try LoadedSet.init(std.testing.allocator);
+    defer set.deinit();
+    try std.testing.expect(!set.contains(remainder_codepoints[0]));
+}
+
+test "LoadedSet.add grows the set and is idempotent" {
+    var set = try LoadedSet.init(std.testing.allocator);
+    defer set.deinit();
+    const cp = remainder_codepoints[0];
+
+    try std.testing.expect(!set.contains(cp));
+    const grew_first = try set.add(cp);
+    try std.testing.expect(grew_first);
+    try std.testing.expect(set.contains(cp));
+
+    const grew_second = try set.add(cp);
+    try std.testing.expect(!grew_second);
 }
 
 // Test helper — linear scan, not for production use.
-fn contains(needle: i32) bool {
-    for (codepoints) |cp| {
+fn containsCp(haystack: []const i32, needle: i32) bool {
+    for (haystack) |cp| {
         if (cp == needle) return true;
     }
     return false;

--- a/src/unicode_codepoints.zig
+++ b/src/unicode_codepoints.zig
@@ -102,6 +102,41 @@ pub const LoadedSet = struct {
     }
 };
 
+/// Decode `bytes` as UTF-8 and add every codepoint found into `dest`.
+/// Malformed byte sequences are skipped one byte at a time rather than
+/// failing the whole scan -- callers pass arbitrary in-hand text (markdown
+/// source, clipboard contents, file paths) that is not guaranteed to be
+/// validated UTF-8, and a best-effort scan is preferable to aborting glyph
+/// loading over a single bad byte.
+pub fn addUtf8Codepoints(dest: *std.AutoHashMap(i32, void), bytes: []const u8) std.mem.Allocator.Error!void {
+    var i: usize = 0;
+    while (i < bytes.len) {
+        const seq_len = std.unicode.utf8ByteSequenceLength(bytes[i]) catch {
+            i += 1;
+            continue;
+        };
+        if (i + seq_len > bytes.len) {
+            i += 1;
+            continue;
+        }
+        const cp = std.unicode.utf8Decode(bytes[i .. i + seq_len]) catch {
+            i += 1;
+            continue;
+        };
+        try dest.put(@intCast(cp), {});
+        i += seq_len;
+    }
+}
+
+/// Decode `bytes` as UTF-8 and return the set of unique codepoints found.
+/// See `addUtf8Codepoints` for malformed-input handling.
+pub fn collectUtf8Codepoints(allocator: std.mem.Allocator, bytes: []const u8) std.mem.Allocator.Error!std.AutoHashMap(i32, void) {
+    var set = std.AutoHashMap(i32, void).init(allocator);
+    errdefer set.deinit();
+    try addUtf8Codepoints(&set, bytes);
+    return set;
+}
+
 test "default codepoints contains ASCII printable range" {
     for (0x20..0x7F) |cp| {
         try std.testing.expect(containsCp(&default_codepoints, @intCast(cp)));
@@ -234,6 +269,43 @@ test "LoadedSet.add grows the set and is idempotent" {
 
     const grew_second = try set.add(cp);
     try std.testing.expect(!grew_second);
+}
+
+test "collectUtf8Codepoints decodes ASCII, Greek, and multi-byte codepoints" {
+    var set = try collectUtf8Codepoints(std.testing.allocator, "A\xCE\xB1\xE2\x86\x92"); // "A" + α (U+03B1) + → (U+2192)
+    defer set.deinit();
+
+    try std.testing.expect(set.contains('A'));
+    try std.testing.expect(set.contains(0x03B1));
+    try std.testing.expect(set.contains(0x2192));
+    try std.testing.expectEqual(@as(u32, 3), set.count());
+}
+
+test "collectUtf8Codepoints deduplicates repeated codepoints" {
+    var set = try collectUtf8Codepoints(std.testing.allocator, "aaa");
+    defer set.deinit();
+    try std.testing.expectEqual(@as(u32, 1), set.count());
+}
+
+test "collectUtf8Codepoints skips malformed bytes without failing" {
+    // 0xFF is never a valid UTF-8 lead byte; the scan should skip it and
+    // continue decoding the valid bytes on either side.
+    var set = try collectUtf8Codepoints(std.testing.allocator, "a\xFFb");
+    defer set.deinit();
+
+    try std.testing.expect(set.contains('a'));
+    try std.testing.expect(set.contains('b'));
+    try std.testing.expectEqual(@as(u32, 2), set.count());
+}
+
+test "addUtf8Codepoints unions into an existing set" {
+    var set = try collectUtf8Codepoints(std.testing.allocator, "a");
+    defer set.deinit();
+    try addUtf8Codepoints(&set, "b");
+
+    try std.testing.expect(set.contains('a'));
+    try std.testing.expect(set.contains('b'));
+    try std.testing.expectEqual(@as(u32, 2), set.count());
 }
 
 // Test helper — linear scan, not for production use.


### PR DESCRIPTION
Closes #77

## Summary

Reduces Selkie's idle peak RSS by lazily loading the glyph atlas instead of eagerly baking all ~2,135 Unicode codepoints across all 5 font variants (body/bold/italic/bold_italic/mono) at startup.

- Split `src/unicode_codepoints.zig` into an eager default set (Basic Latin, Latin-1, General Punctuation — ~303 codepoints) and a lazy remainder pool (Latin Ext A/B, Greek, sup/subscripts, currency, letterlike, arrows, math operators, misc technical, geometric shapes, misc symbols, dingbats, ligatures — ~1,832 codepoints).
- Added `App.ensureGlyphs(codepoints)` with an accumulating, growth-only `loaded_codepoints` set. When new codepoints are needed, it rebuilds all 5 font variants exactly once via `unloadFonts` + a single atlas per font (no texture proliferation), preserving the atlas on rebuild failure.
- Wired load-time collection into `newTabWithFile`/`loadMarkdown`: unions a raw UTF-8 scan of the markdown source (captures prose, code, tables, headings, mermaid node/edge/title labels — literal in the fenced source) with a walk of the built layout tree's text runs (captures synthesized math glyphs like pi, arrows, fraction bars). Relayouts once if the codepoint set grew, fitting the existing double-relayout pattern.
- Added narrow runtime `ensureGlyphs` hooks at the three arbitrary-text insertion points (editor insert/paste, search input, command-palette input), scanning only newly inserted bytes — idempotent and growth-only.
- Documented a reproducible `/usr/bin/time -v` peak-RSS/startup measurement procedure in `docs/memory-profiling.md`, with before/after numbers for a one-line file and the full GFM sample doc.

## Key decisions

- **Load-time, not draw-time, expansion**: glyphs are ensured before the final layout pass, so `measureTextEx` always runs against a font that already contains the glyph — correct layout metrics on the first frame, no one-frame "?" flash.
- **Single atlas per font, rebuild not proliferate**: `ensureGlyphs` unloads and rebuilds each of the 5 font variants once when the codepoint set grows, rather than stacking additional textures.
- **Two-source codepoint collection**: a raw UTF-8 scan of the markdown source is required because mermaid diagram labels are drawn from the parsed model, not from `LayoutTree` text runs — a text-runs-only walk would miss them. The text-runs walk is retained solely to catch synthesized math glyphs that don't appear literally in the source.
- **Baseline-first, go/no-go gate**: before building the lazy-loading machinery, an isolation experiment confirmed the eager 2,135-codepoint × 5-variant atlas accounted for ~18MB (~9-10%) of the ~200MB baseline RSS, justifying the work.
- **Results**: one-line file idle peak RSS dropped from ~194.5MB to ~185.2MB (~4.8% reduction); no missing-glyph regressions verified against `docs/github-markdown-samples.md`.

Token usage (approximate, this issue only): 128028 output tokens
